### PR TITLE
Miscellaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ creating your own 3D renderer using e2.
 To give you a better picture of what exactly e2 does, look at the examples.
 But in short:
 
-```rs
+```rust
 let cx = e2::Context::new(&window, wgpu::Backends::PRIMARY);
 cx.configure_surface(width, height, wgpu::PresentMode::Mailbox);
 

--- a/examples/draw.rs
+++ b/examples/draw.rs
@@ -116,8 +116,8 @@ fn main() -> anyhow::Result<()> {
                 let view = swapchain.texture.create_view(&Default::default());
 
                 let mut frame = e2::Frame::new(&cx);
-                mesh.free();
-                batch.free();
+                mesh.reset();
+                batch.reset();
 
                 {
                     let mut pass = e2::SimpleRenderPass {

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -308,9 +308,9 @@ fn main() -> anyhow::Result<()> {
                 frame.submit(&cx);
                 swapchain.present();
 
-                renderer.free();
+                renderer.reset();
 
-                text_renderer.free();
+                text_renderer.reset();
                 local_pool.run_until_stalled();
             }
             Event::MainEventsCleared => {

--- a/src/batch_render.rs
+++ b/src/batch_render.rs
@@ -70,7 +70,7 @@ impl BatchRenderer {
     /// Resets the previously allocated buffers, making them available for reuse.
     ///
     /// Call this at the start or end of every frame in order to maintain acceptable spatial performance.
-    pub fn free(&mut self) {
+    pub fn reset(&mut self) {
         for buf in &mut self.instances {
             buf.free = true;
         }

--- a/src/color.rs
+++ b/src/color.rs
@@ -3,19 +3,26 @@ use crate::*;
 /// Simple sRGB color type with an alpha channel.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct Color {
+    /// The red channel of the color.
     pub r: f32,
+    /// The green channel of the color.
     pub g: f32,
+    /// The blue channel of the color.
     pub b: f32,
+    /// The alpha channel of the color.
     pub a: f32,
 }
 
+#[allow(missing_docs)]
 impl Color {
     pub const WHITE: Self = Color::new(1., 1., 1., 1.);
     pub const BLACK: Self = Color::new(0., 0., 0., 1.);
     pub const RED: Self = Color::new(1., 0., 0., 1.);
     pub const GREEN: Self = Color::new(0., 1., 0., 1.);
     pub const BLUE: Self = Color::new(0., 0., 1., 1.);
+}
 
+impl Color {
     /// Creates a new color.
     #[inline]
     pub const fn new(r: f32, g: f32, b: f32, a: f32) -> Self {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
 /// Stores GPU context handles, most notably the device and queue.
+#[allow(missing_docs)]
 #[derive(Debug)]
 pub struct Context {
     pub instance: wgpu::Instance,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -78,9 +78,9 @@ impl From<BatchDraw> for GpuDraw {
     }
 }
 
-/// Stores the same data as [Draw], but in a GPU-friendly manner.
+/// Stores the same data as [BatchDraw], but in a GPU-friendly manner.
 ///
-/// When uploading, convert to `Std430` first with [crevice::AsStd430].
+/// When uploading, convert to `Std430` first with [crevice::std430::AsStd430].
 #[derive(AsStd430, Debug, Clone, Copy, PartialEq)]
 pub struct GpuDraw {
     pub color: mint::Vector4<f32>,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -2,7 +2,8 @@ use crate::*;
 use std::sync::Arc;
 use typed_arena::Arena as TypedArena;
 
-/// Data that exists for the lifetime of a frame,
+/// Data that exists for the lifetime of a frame.
+#[allow(missing_debug_implementations)]
 pub struct Frame {
     /// The command encoder for this frame,
     pub cmd: wgpu::CommandEncoder,
@@ -28,6 +29,7 @@ impl Frame {
 }
 
 /// Typed arenas for various GPU resources that need to live as long as the frame.
+#[allow(missing_debug_implementations)]
 pub struct FrameArena {
     pub render_pipelines: TypedArena<Arc<wgpu::RenderPipeline>>,
     pub bind_groups: TypedArena<Arc<wgpu::BindGroup>>,

--- a/src/growing.rs
+++ b/src/growing.rs
@@ -44,7 +44,7 @@ impl GrowingBufferArena {
     /// Resets all the buffer allocations.
     ///
     /// All `ArenaAllocation`s returned from this arena should now be considered invalid.
-    pub fn free(&mut self) {
+    pub fn reset(&mut self) {
         for (_, cursor) in &mut self.buffers {
             *cursor = 0;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(missing_copy_implementations)]
 #![warn(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+
 mod batch_render;
 mod bind_cache;
 mod color;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 /// GPU vertex with position and UV.
 #[repr(C)]
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Vertex {
     pub pos: [f32; 2],

--- a/src/mesh_render.rs
+++ b/src/mesh_render.rs
@@ -61,8 +61,8 @@ impl MeshRenderer {
     /// Resets the previously allocated buffers, making them available for reuse.
     ///
     /// Call this at the start or end of every frame in order to maintain acceptable spatial performance.
-    pub fn free(&mut self) {
-        self.uniforms.free();
+    pub fn reset(&mut self) {
+        self.uniforms.reset();
     }
 
     /// Binds a sampler for use with the proceeding draw calls.

--- a/src/mesh_render.rs
+++ b/src/mesh_render.rs
@@ -2,7 +2,7 @@ use crate::*;
 use crevice::std430::AsStd430;
 use std::{num::NonZeroU64, sync::Arc};
 
-/// [MeshRenderer] is a simplified interface to drawing a mesh and texture
+/// Simplified interface for drawing a mesh and texture
 /// with a specified "draw configuration" ([Draw]).
 #[derive(Debug)]
 pub struct MeshRenderer {

--- a/src/mesh_render.rs
+++ b/src/mesh_render.rs
@@ -3,7 +3,7 @@ use crevice::std430::AsStd430;
 use std::{num::NonZeroU64, sync::Arc};
 
 /// Simplified interface for drawing a mesh and texture
-/// with a specified "draw configuration" ([Draw]).
+/// with a specified "draw configuration" ([MeshDraw]).
 #[derive(Debug)]
 pub struct MeshRenderer {
     uniforms: GrowingBufferArena,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,7 +1,5 @@
 use crate::*;
 
-pub use wgpu::TextureViewDimension::*;
-
 /// Simplified render pipeline descriptor.
 #[derive(Debug, Clone)]
 pub struct SimpleRenderPipeline<'a> {

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -45,6 +45,7 @@ impl<'a> SimpleRenderPass<'a> {
 /// [wgpu::RenderPipeline] equivalent, but with more sensible lifetimes.
 ///
 /// Overrides methods that take [std::sync::Arc] GPU resources and allocate thems on `arena`.
+#[allow(missing_debug_implementations)]
 pub struct ArenaRenderPass<'a> {
     pub arena: &'a FrameArena,
     pub pass: wgpu::RenderPass<'a>,

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -120,6 +120,7 @@ impl Slot3MeshRenderer for SpriteRenderer {
 }
 
 /// The visual contents (texture or color) of a sprite.
+#[derive(Debug)]
 pub enum SpriteContent<'a> {
     /// The sprite is textured.
     Textured {

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -59,8 +59,8 @@ impl SpriteRenderer {
     /// Resets the previously allocated buffers, making them available for reuse.
     ///
     /// Call this at the start or end of every frame in order to maintain acceptable spatial performance.
-    pub fn free(&mut self) {
-        self.renderer.free();
+    pub fn reset(&mut self) {
+        self.renderer.reset();
     }
 
     /// Binds a sampler for use with the proceeding draw calls.

--- a/src/sprite_batch.rs
+++ b/src/sprite_batch.rs
@@ -59,8 +59,8 @@ impl SpriteBatchRenderer {
     /// Resets the previously allocated buffers, making them available for reuse.
     ///
     /// Call this at the start or end of every frame in order to maintain acceptable spatial performance.
-    pub fn free(&mut self) {
-        self.renderer.free();
+    pub fn reset(&mut self) {
+        self.renderer.reset();
     }
 
     /// Binds a sampler for use with the proceeding draw calls.

--- a/src/sprite_batch.rs
+++ b/src/sprite_batch.rs
@@ -124,6 +124,7 @@ impl Slot3BatchRenderer for SpriteBatchRenderer {
 }
 
 /// Draw data for a single instance in a textured batched sprite draw.
+#[derive(Debug, Clone, Copy)]
 pub struct SpriteBatchTexturedDraw {
     /// Color to multiply texture color with.
     /// Using [Color::WHITE] will mean the texture will render as-is.
@@ -138,6 +139,7 @@ pub struct SpriteBatchTexturedDraw {
 }
 
 /// Draw data for a single instance in a non-textured batched sprite draw.
+#[derive(Debug, Clone, Copy)]
 pub struct SpriteBatchColorDraw {
     /// Color to fill with.
     pub color: Color,
@@ -148,6 +150,7 @@ pub struct SpriteBatchColorDraw {
 }
 
 /// Sprite batch data, either in the form of texture sprites or colored sprites.
+#[derive(Debug)]
 pub enum SpriteBatch<'a> {
     Textured {
         texture: &'a Texture,

--- a/src/text.rs
+++ b/src/text.rs
@@ -75,6 +75,7 @@ impl FontBrush {
 }
 
 /// Text rendering helper type which renders text using a [FontBrush].
+#[derive(Debug)]
 pub struct TextRenderer {
     staging_belt: wgpu::util::StagingBelt,
 }
@@ -172,6 +173,7 @@ impl TextRenderer {
 }
 
 /// Draw data for rendering text.
+#[derive(Debug)]
 pub struct TextDraw<'a> {
     /// Top-left of the text.
     pub origin: glam::Vec2,

--- a/src/text.rs
+++ b/src/text.rs
@@ -90,7 +90,7 @@ impl TextRenderer {
     ///
     /// Call this *after* [Frame::submit].
     #[inline]
-    pub fn free(&mut self) {
+    pub fn reset(&mut self) {
         self.staging_belt.recall()
     }
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -37,6 +37,7 @@ impl Texture {
 }
 
 /// Texture descriptor for image texture; i.e. textures initialized with pixel data.
+#[derive(Debug)]
 pub struct ImageTexture<'a> {
     pub format: wgpu::TextureFormat,
     pub pixels: Cow<'a, [u8]>,
@@ -117,6 +118,7 @@ impl<'a> ImageTexture<'a> {
 }
 
 /// Texture descriptor for rendering use.
+#[derive(Debug, Clone, Copy)]
 pub struct RenderTexture {
     pub format: wgpu::TextureFormat,
     pub samples: u32,


### PR DESCRIPTION
Add a few docs, warn on `rustdoc::broken_intra_doc_links`, `missing_copy_implementations` & `missing_debug_implementations`, rename `free` methods to `reset`, fix some doc links and add some missing derives.